### PR TITLE
Comment out labels

### DIFF
--- a/SupportSDKSamples/Sample/Sample/ViewController.swift
+++ b/SupportSDKSamples/Sample/Sample/ViewController.swift
@@ -36,7 +36,7 @@ final class ViewController: UIViewController, UINavigationControllerDelegate {
     var hcConfig: HelpCenterUiConfiguration {
         let hcConfig = HelpCenterUiConfiguration()
         hcConfig.showContactOptions = true
-        hcConfig.labels = ["label"] // only hc articles with the label 'label' will appear
+        // hcConfig.labels = ["label"] // only hc articles with the label 'label' will appear
         return hcConfig
     }
     


### PR DESCRIPTION
Commenting this line out because it's very easy to miss that this is set, sending people down a rabbit hole trying to figure out why their articles aren't showing.