### PR TITLE
Update Versions For Latest Releases

### DIFF
--- a/AnswerBotSDKSample/AnswerBotSample.xcodeproj/project.pbxproj
+++ b/AnswerBotSDKSample/AnswerBotSample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -372,7 +372,7 @@
 			repositoryURL = "https://github.com/zendesk/answer_bot_sdk_ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
+				minimumVersion = 5.0.0;
 			};
 		};
 		74EEBBF527F7513A0098A9A2 /* XCRemoteSwiftPackageReference "support_sdk_ios" */ = {
@@ -380,7 +380,7 @@
 			repositoryURL = "https://github.com/zendesk/support_sdk_ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.0.0;
+				minimumVersion = 8.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/AnswerBotSDKSample/AnswerBotSample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AnswerBotSDKSample/AnswerBotSample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/answer_bot_providers_sdk_ios",
       "state" : {
-        "revision" : "7e4e58d99a28682097b2e6388643e0c8beb203e1",
-        "version" : "4.0.0"
+        "revision" : "d59d4ca6e0ebb01e640943caa63fe1efbe81e76a",
+        "version" : "5.0.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/answer_bot_sdk_ios",
       "state" : {
-        "revision" : "b251816ae50847159f3d578193b4419e218d9821",
-        "version" : "4.0.0"
+        "revision" : "a2ab66fa2d9303a56b6942b745cfe6dfd94960df",
+        "version" : "5.0.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/commonui_sdk_ios",
       "state" : {
-        "revision" : "fb58b008ebf81c209aab95fd615a7f04bd917163",
-        "version" : "8.0.0"
+        "revision" : "193f7daf7b7ad9788ceffa2d7cd285cd48e63e57",
+        "version" : "9.0.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/core_sdk_ios",
       "state" : {
-        "revision" : "15fab6b53b33c194956b56aba70b9ee3f00901c0",
-        "version" : "4.0.0"
+        "revision" : "9f713da35ec46ada0245f7d89a43e15e849cd131",
+        "version" : "5.0.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/messaging_sdk_ios",
       "state" : {
-        "revision" : "6149dff5446e6c5de5c6a020d3dcd67c52e75169",
-        "version" : "5.0.0"
+        "revision" : "825cc5fcb0e7bcda5bb713089245dae31ee07ae4",
+        "version" : "6.0.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/messagingapi_sdk_ios",
       "state" : {
-        "revision" : "cf9be0454a1524244ab41a4f2c0f53e80da413d6",
-        "version" : "5.0.0"
+        "revision" : "2f21e014a1f284edf484faf39b2b6fe377ec8c64",
+        "version" : "6.0.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/sdkconfigurations_sdk_ios",
       "state" : {
-        "revision" : "25ebb9ae75aef4451a94165b0b34ab9562647680",
-        "version" : "3.0.0"
+        "revision" : "fec7b8bf3d85cb895a0820a2f9d102f9d6ba3070",
+        "version" : "4.0.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/support_providers_sdk_ios",
       "state" : {
-        "revision" : "55f514d69ec762838ea625e95b222111ad858ab8",
-        "version" : "7.0.0"
+        "revision" : "66b49f0a0e213ee0ce5c4fca0847a1f43fbc7cee",
+        "version" : "8.0.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/support_sdk_ios",
       "state" : {
-        "revision" : "caaefa4ca8d4f3ebf7a1b0443990672a183af11a",
-        "version" : "7.0.0"
+        "revision" : "ad6b6550dd789b9d2a1da4acba174c176fe7122e",
+        "version" : "8.0.0"
       }
     }
   ],

--- a/ChatSDKSamples/ChatSDK_Auth/ChatSDK_Auth.xcodeproj/project.pbxproj
+++ b/ChatSDKSamples/ChatSDK_Auth/ChatSDK_Auth.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -363,7 +363,7 @@
 			repositoryURL = "https://github.com/zendesk/chat_sdk_ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
+				minimumVersion = 5.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/SupportSDKSamples/Podfile
+++ b/SupportSDKSamples/Podfile
@@ -1,6 +1,6 @@
 source 'https://github.com/CocoaPods/Specs.git' 
 
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 target 'CocoaPodSample' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
@@ -8,5 +8,5 @@ target 'CocoaPodSample' do
 
   # Pods for CocoaPodSample
 
-  pod 'ZendeskSupportSDK', '~> 7.0.0'
+  pod 'ZendeskSupportSDK', '~> 8.0.0'
 end

--- a/SupportSDKSamples/Podfile.lock
+++ b/SupportSDKSamples/Podfile.lock
@@ -1,20 +1,20 @@
 PODS:
-  - ZendeskCommonUISDK (8.0.0)
-  - ZendeskCoreSDK (4.0.0)
-  - ZendeskMessagingAPISDK (5.0.0):
-    - ZendeskSDKConfigurationsSDK (~> 3.0.0)
-  - ZendeskMessagingSDK (5.0.0):
-    - ZendeskCommonUISDK (~> 8.0.0)
-    - ZendeskMessagingAPISDK (~> 5.0.0)
-  - ZendeskSDKConfigurationsSDK (3.0.0)
-  - ZendeskSupportProvidersSDK (7.0.0):
-    - ZendeskCoreSDK (~> 4.0.0)
-  - ZendeskSupportSDK (7.0.0):
-    - ZendeskMessagingSDK (~> 5.0.0)
-    - ZendeskSupportProvidersSDK (~> 7.0.0)
+  - ZendeskCommonUISDK (9.0.0)
+  - ZendeskCoreSDK (5.0.0)
+  - ZendeskMessagingAPISDK (6.0.0):
+    - ZendeskSDKConfigurationsSDK (~> 4.0.0)
+  - ZendeskMessagingSDK (6.0.0):
+    - ZendeskCommonUISDK (~> 9.0.0)
+    - ZendeskMessagingAPISDK (~> 6.0.0)
+  - ZendeskSDKConfigurationsSDK (4.0.0)
+  - ZendeskSupportProvidersSDK (8.0.0):
+    - ZendeskCoreSDK (~> 5.0.0)
+  - ZendeskSupportSDK (8.0.0):
+    - ZendeskMessagingSDK (~> 6.0.0)
+    - ZendeskSupportProvidersSDK (~> 8.0.0)
 
 DEPENDENCIES:
-  - ZendeskSupportSDK (~> 7.0.0)
+  - ZendeskSupportSDK (~> 8.0.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -27,14 +27,14 @@ SPEC REPOS:
     - ZendeskSupportSDK
 
 SPEC CHECKSUMS:
-  ZendeskCommonUISDK: d2dfaa56b9da2658dac0e078022bf918959b5854
-  ZendeskCoreSDK: bd3bc4e7ac4e508de20425a1eac3512a2d2c86bb
-  ZendeskMessagingAPISDK: 355f623d727620755b4041a42dffda4fb28ab90c
-  ZendeskMessagingSDK: 66b82e44c774359ac14f5fb21765aa73d0d174dd
-  ZendeskSDKConfigurationsSDK: 6b4b0941d46afd7352682c4ce764d5999535b7d4
-  ZendeskSupportProvidersSDK: 44f6639b5845815d4111b97ff00218f122ef9e33
-  ZendeskSupportSDK: cae2bd10740bed62d8f89b78e6eea42713cd1e3c
+  ZendeskCommonUISDK: b87f90874386ebcc01f4b2a0b20a28c62658987a
+  ZendeskCoreSDK: cdc814e7fd64764fb0b0acb04e596df437708faa
+  ZendeskMessagingAPISDK: 9ce539eebcaa014fe6acc44da31262a2c52891c1
+  ZendeskMessagingSDK: ccc8dd41b774b0d2f94733505b9f1882d72184da
+  ZendeskSDKConfigurationsSDK: 79c444da987390456ec05657ffa2f5ca0eb54aef
+  ZendeskSupportProvidersSDK: 4aafe8114a9bba1a98dc03ca14d8fa6510cf4e70
+  ZendeskSupportSDK: 8cf921c496269bb5f53aac9320f3d002a793991d
 
-PODFILE CHECKSUM: 15f5b70662f752d4a9e638fa6afa2c820eeddf33
+PODFILE CHECKSUM: 1a12a9618ae44efea6e48cc4c3a3d96780c066ef
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.13.0

--- a/TalkSDKSamples/Podfile
+++ b/TalkSDKSamples/Podfile
@@ -2,7 +2,7 @@ workspace 'TalkSDKSamples'
 
 install! 'cocoapods', :warn_for_unused_master_specs_repo => false
 use_frameworks!
-platform :ios, '10.0'
+platform :ios, '12.0'
 
 target 'TalkSDKSamples-Swift' do
 	project 'TalkSDKSamples-Swift'

--- a/UnifiedSDK/UnifiedObjC.xcodeproj/project.pbxproj
+++ b/UnifiedSDK/UnifiedObjC.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -376,7 +376,7 @@
 			repositoryURL = "https://github.com/zendesk/chat_sdk_ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
+				minimumVersion = 5.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/UnifiedSDK/UnifiedObjC.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/UnifiedSDK/UnifiedObjC.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/chat_providers_sdk_ios",
       "state" : {
-        "revision" : "cd8f46c012b33fed262fe70a0bae0da88c25cbdf",
-        "version" : "5.0.0"
+        "revision" : "b28eba3c480a2c53c34f3840d0f43e8c2e8adeb8",
+        "version" : "4.0.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/chat_sdk_ios",
       "state" : {
-        "revision" : "991ce07986e147a66feef7bdc3d2a1ad973a0d88",
-        "version" : "5.0.0"
+        "revision" : "fc4901b5d0594d652c66158a24a23a1d35344b21",
+        "version" : "4.0.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/commonui_sdk_ios",
       "state" : {
-        "revision" : "193f7daf7b7ad9788ceffa2d7cd285cd48e63e57",
-        "version" : "9.0.0"
+        "revision" : "fb58b008ebf81c209aab95fd615a7f04bd917163",
+        "version" : "8.0.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/messaging_sdk_ios",
       "state" : {
-        "revision" : "825cc5fcb0e7bcda5bb713089245dae31ee07ae4",
-        "version" : "6.0.0"
+        "revision" : "6149dff5446e6c5de5c6a020d3dcd67c52e75169",
+        "version" : "5.0.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/messagingapi_sdk_ios",
       "state" : {
-        "revision" : "2f21e014a1f284edf484faf39b2b6fe377ec8c64",
-        "version" : "6.0.0"
+        "revision" : "cf9be0454a1524244ab41a4f2c0f53e80da413d6",
+        "version" : "5.0.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/sdkconfigurations_sdk_ios",
       "state" : {
-        "revision" : "fec7b8bf3d85cb895a0820a2f9d102f9d6ba3070",
-        "version" : "4.0.0"
+        "revision" : "25ebb9ae75aef4451a94165b0b34ab9562647680",
+        "version" : "3.0.0"
       }
     }
   ],

--- a/UnifiedSDK/UnifiedSDK.xcodeproj/project.pbxproj
+++ b/UnifiedSDK/UnifiedSDK.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -383,7 +383,7 @@
 			repositoryURL = "https://github.com/zendesk/chat_sdk_ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
+				minimumVersion = 5.0.0;
 			};
 		};
 		C67B1E3D29D2EABB003B3540 /* XCRemoteSwiftPackageReference "support_sdk_ios" */ = {
@@ -391,7 +391,7 @@
 			repositoryURL = "https://github.com/zendesk/support_sdk_ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.0.0;
+				minimumVersion = 8.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/UnifiedSDK/UnifiedSDK.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/UnifiedSDK/UnifiedSDK.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/chat_providers_sdk_ios",
       "state" : {
-        "revision" : "b28eba3c480a2c53c34f3840d0f43e8c2e8adeb8",
-        "version" : "4.0.0"
+        "revision" : "cd8f46c012b33fed262fe70a0bae0da88c25cbdf",
+        "version" : "5.0.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/chat_sdk_ios",
       "state" : {
-        "revision" : "fc4901b5d0594d652c66158a24a23a1d35344b21",
-        "version" : "4.0.0"
+        "revision" : "991ce07986e147a66feef7bdc3d2a1ad973a0d88",
+        "version" : "5.0.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/commonui_sdk_ios",
       "state" : {
-        "revision" : "fb58b008ebf81c209aab95fd615a7f04bd917163",
-        "version" : "8.0.0"
+        "revision" : "193f7daf7b7ad9788ceffa2d7cd285cd48e63e57",
+        "version" : "9.0.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/core_sdk_ios",
       "state" : {
-        "revision" : "15fab6b53b33c194956b56aba70b9ee3f00901c0",
-        "version" : "4.0.0"
+        "revision" : "9f713da35ec46ada0245f7d89a43e15e849cd131",
+        "version" : "5.0.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/messaging_sdk_ios",
       "state" : {
-        "revision" : "6149dff5446e6c5de5c6a020d3dcd67c52e75169",
-        "version" : "5.0.0"
+        "revision" : "825cc5fcb0e7bcda5bb713089245dae31ee07ae4",
+        "version" : "6.0.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/messagingapi_sdk_ios",
       "state" : {
-        "revision" : "cf9be0454a1524244ab41a4f2c0f53e80da413d6",
-        "version" : "5.0.0"
+        "revision" : "2f21e014a1f284edf484faf39b2b6fe377ec8c64",
+        "version" : "6.0.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/sdkconfigurations_sdk_ios",
       "state" : {
-        "revision" : "25ebb9ae75aef4451a94165b0b34ab9562647680",
-        "version" : "3.0.0"
+        "revision" : "fec7b8bf3d85cb895a0820a2f9d102f9d6ba3070",
+        "version" : "4.0.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/support_providers_sdk_ios",
       "state" : {
-        "revision" : "55f514d69ec762838ea625e95b222111ad858ab8",
-        "version" : "7.0.0"
+        "revision" : "66b49f0a0e213ee0ce5c4fca0847a1f43fbc7cee",
+        "version" : "8.0.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zendesk/support_sdk_ios",
       "state" : {
-        "revision" : "caaefa4ca8d4f3ebf7a1b0443990672a183af11a",
-        "version" : "7.0.0"
+        "revision" : "ad6b6550dd789b9d2a1da4acba174c176fe7122e",
+        "version" : "8.0.0"
       }
     }
   ],


### PR DESCRIPTION
Updating SDK versions for the latest Classic SDKs releases.

See the release notes for the [Unified SDK](https://developer.zendesk.com/documentation/classic-web-widget-sdks/unified-sdk/ios/release_notes/#7th-november-2023) and the [Talk SDK](https://developer.zendesk.com/documentation/classic-web-widget-sdks/talk-sdk/ios/release_notes/#release-notes) for the latest SDK versions.